### PR TITLE
Use setuptools build backend

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt install -y gmsh
 
         # Install
-        uv pip install .
+        uv pip install .[dev]
 
         # Lint and test
         uv run --locked ruff check ./device_inductance

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ build:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group dev
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync
     install:
       - "true"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ build:
       - asdf install uv latest
       - asdf global uv latest
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv pip install -e .[dev]
     install:
       - "true"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.0 - 2025-06-26
+
+### Changed
+
+* Use setuptools build backend instead of hatchling
+* Include py.typed marker in wheel
+* Remove `__author__` field that was deprecated at the language level
+
 ## 2.1.0 - 2025-06-12
 
 ### Changed

--- a/device_inductance/__init__.py
+++ b/device_inductance/__init__.py
@@ -3,7 +3,6 @@ from typing import Literal
 from pathlib import Path
 
 __version__ = metadata(str(__package__))["Version"]
-__author__ = metadata(str(__package__))["Author"]
 
 from omas import ODS, load_omas_json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "device_inductance"
-version = "2.1.0"
+version = "2.2.0"
 description = "Tokamak core inductance matrices and flux tables"
 authors = [{ name = "Commonwealth Fusion Systems", email = "jlogan@cfs.energy" }]
 requires-python = ">=3.10, <3.14"
 readme = "./README.md"
 license = "MIT OR Apache-2.0"
+license-files = ["LICEN[CS]E*"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
@@ -16,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "numpy>=2,<3",
@@ -29,7 +29,7 @@ dependencies = [
     "cfsem>=2.3.1,<3",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest==8.3.5",
     "coverage==7.8.0",
@@ -43,8 +43,14 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["device_inductance"]
+
+[tool.setuptools.package-data]
+device_inductance = ['py.typed']
 
 [tool.ruff]
 target-version = "py311"

--- a/uv.lock
+++ b/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "device-inductance"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cfsem" },
@@ -460,7 +460,7 @@ dependencies = [
     { name = "shapely" },
 ]
 
-[package.dev-dependencies]
+[package.optional-dependencies]
 dev = [
     { name = "coverage" },
     { name = "matplotlib" },
@@ -476,27 +476,24 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cfsem", specifier = ">=2.3.1,<3" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = "==7.8.0" },
     { name = "gmsh", specifier = ">=4.13.1,<5" },
     { name = "interpn", specifier = ">=0.2.5,<0.3" },
+    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.9.1,<4" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.6.12" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.29.1" },
+    { name = "mktestdocs", marker = "extra == 'dev'", specifier = "==0.2.4" },
     { name = "numpy", specifier = ">=2,<3" },
     { name = "omas", specifier = ">=0.94.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.402" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
     { name = "rich", specifier = ">=14.0.0,<15" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.8" },
     { name = "scipy", specifier = "~=1.12" },
     { name = "shapely", specifier = ">=2.1.0,<3" },
 ]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", specifier = "==7.8.0" },
-    { name = "matplotlib", specifier = ">=3.9.1,<4" },
-    { name = "mkdocs", specifier = ">=1.6.0" },
-    { name = "mkdocs-material", specifier = ">=9.6.12" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
-    { name = "mktestdocs", specifier = "==0.2.4" },
-    { name = "pyright", specifier = "==1.1.402" },
-    { name = "pytest", specifier = "==8.3.5" },
-    { name = "ruff", specifier = "==0.11.8" },
-]
+provides-extras = ["dev"]
 
 [[package]]
 name = "dnspython"


### PR DESCRIPTION
## 2.2.0 - 2025-06-26

### Changed

* Use setuptools build backend instead of hatchling
* Include py.typed marker in wheel
* Remove `__author__` field that was deprecated at the language level