### PR TITLE
Implement self-field for irregular coils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.0.0 - 2025-07-01
+
+### Added
+
+* Add `local` module with self-field flux and B-field calculations for coil winding packs
+* Add functionality for mapping coil winding packs on irregular grids (like VS coils) on to a regular grid for local field solve
+
+### Changed
+
+* !Return a more featured struct of data from coil self-field calcs instead of a tuple
+* !Return MulticubicRegular interpolators as coil field interpolators instead of MulticubicRectilinear
+* Make coil self-field calc return types non-optional since all non-error branches now produce a valid output
+
 ## 2.2.0 - 2025-06-26
 
 ### Changed

--- a/device_inductance/coils.py
+++ b/device_inductance/coils.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from functools import cached_property
 
 import numpy as np
 from numpy.typing import NDArray
 from omas import ODS
+from shapely import Polygon
 
 from cfsem import (
     self_inductance_lyle6,
@@ -14,11 +14,9 @@ from cfsem import (
     self_inductance_circular_ring_wien,
 )
 
-from .utils import solve_flux_axisymmetric, calc_flux_density_from_flux
+from interpn import MulticubicRegular
 
-from interpn import MulticubicRectilinear
-
-from device_inductance.logging import log
+from device_inductance.local import local_fields, LocalFields
 
 
 @dataclass(frozen=True)
@@ -58,93 +56,17 @@ class Coil:
     """Discretized circular filaments describing the coil's winding pattern"""
 
     @cached_property
-    def grids(self) -> Optional[tuple[NDArray, NDArray]]:
-        """Generate a set of regular r,z grids that span the coil winding pack centers exactly
-        if possible, or None if the winding pack can't be represented exactly.
-
-        Adds 4 grid cells of padding around the winding pack to deconflict the
-        cells with nonzero current density from the boundary conditions of a
-        flux solve.
-
-        If only one unit cell is present on either axis, the grid will be
-        expanded 1cm in either direction.
-        """
-
-        # Get coordinates with a unit cell
-        unique_r = np.array(sorted(list(set([f.r for f in self.filaments]))))  # [m]
-        unique_z = np.array(sorted(list(set([f.z for f in self.filaments]))))
-
-        # Make sure there are enough unit cells to work with,
-        # expanding dimensions if necessary
-        if len(unique_r) == 1:
-            r = unique_r[0]
-            unique_r = [r - 1e-2, r, r + 1e-2]
-        if len(unique_z) == 1:
-            z = unique_z[0]
-            unique_z = [z - 1e-2, z, z + 1e-2]
-        if len(unique_r) < 2 or len(unique_z) < 2:
-            log().error("Failed to expand coil grid dimensionality")
-            return None
-
-        # Check if the coordinates have regular spacing,
-        # which is required to support the finite difference solve
-        drs = np.diff(unique_r)
-        drmean = np.mean(drs)
-        if np.any(np.abs(drs - drmean) / drmean > 1e-4):
-            log().warning(
-                f"Coil {self.name} filaments are not on a regular grid; skipping grid for smooth self-field"
-            )
-            return None
-        dzs = np.diff(unique_z)
-        dzmean = np.mean(dzs)
-        if np.any(np.abs(dzs - dzmean) / dzmean > 1e-4):
-            log().warning(
-                f"Coil {self.name} filaments are not on a regular grid; skipping grid for smooth self-field"
-            )
-            return None
-
-        # Extend grids by a few cells outside the winding pack
-        # 7 is the true minimum; 2x 4th-order finite difference patches
-        # will be stacked to extract the flux then the flux density, which means
-        # 7 cells see direct interaction with boundary conditions and must not
-        # have nonzero current density to produce sane results; npad = 6 produces junk outputs.
-        npad = 7
-        nr = len(unique_r) + 2 * npad
-        nz = len(unique_z) + 2 * npad
-        r_pad = npad * drmean
-        z_pad = npad * dzmean
-        rgrid = np.linspace(unique_r[0] - r_pad, unique_r[-1] + r_pad, nr)
-        zgrid = np.linspace(unique_z[0] - z_pad, unique_z[-1] + z_pad, nz)
-
-        # Make sure the grid doesn't cross zero.
-        # If this check becomes a problem, there is an alternate strategy
-        # to double resolution and spread the coil's current density mapping
-        # across more than one neighboring cell, but that is too much complexity
-        # to implement proactively.
-        if rgrid[0] < 0.0:
-            log().error(f"Coil {self.name} grid for smooth self-field crossed r=0")
-            return None
-
-        return (rgrid, zgrid)
+    def grids(self) -> tuple[NDArray, NDArray]:
+        """Generate a grid that spans the winding pack, landing exactly on the windings if possible."""
+        return self.local_fields.grids
 
     @cached_property
-    def meshes(self) -> Optional[tuple[NDArray, NDArray]]:
-        """Generate a set of regular r,z meshes that span the coil winding pack centers exactly
-        if possible, or None if the winding pack can't be represented exactly.
-
-        Adds 4 grid cells of padding around the winding pack to deconflict the
-        cells with nonzero current density from the boundary conditions of a
-        flux solve.
-        """
-        grids = self.grids
-        if grids is not None:
-            rmesh, zmesh = np.meshgrid(*grids, indexing="ij")
-            return (rmesh, zmesh)  # Unpack and repack for pyright...
-        else:
-            return None
+    def meshes(self) -> tuple[NDArray, NDArray]:
+        """Generate a meshgrid that spans the winding pack, landing exactly on the windings if possible."""
+        return self.local_fields.meshes
 
     @cached_property
-    def local_fields(self) -> Optional[tuple[NDArray, NDArray, NDArray]]:
+    def local_fields(self) -> LocalFields:
         """
         Solve the local self-field flux and flux density per amp by mapping the
         coil section to a continuous current density distribution and solving the
@@ -152,59 +74,38 @@ class Coil:
         B-field from the flux field via 4th-order finite difference.
 
         Returns:
-            (psi, br, bz) [Wb/A, T/A, T/A] 2D arrays of poloidal flux and flux density per amp of coil current
+            Structure containing local field map components and interpolators
         """
-        grids = self.grids
-        meshes = self.meshes
-        if grids is not None and meshes is not None:
-            rgrid, zgrid = grids
-            rmesh, zmesh = meshes
-            dr = rgrid[1] - rgrid[0]  # [m]
-            dz = zgrid[1] - zgrid[0]  # [m]
-            area = dr * dz  # [m^2]
+        # Polygon section representation
+        # As a heuristic, treat each filament as a rectangle with side length that is
+        # half the smallest distance between two sequential filaments.
+        # These polygons are only used if the windings do not fall on a regular grid
+        # or are too close to r=0 to allow padding the grid to preserve boundary conditions.
+        drs = np.diff(self.rs)
+        dzs = np.diff(self.zs)
+        w = np.min(np.linalg.norm((drs, dzs), axis=0)) / 2
 
-            # Map current density per amp
-            jtor = np.zeros_like(meshes[0])  # [A-turns/m^2 / A]
-            for f in self.filaments:
-                # Get indices of location of this filament
-                ri = np.argmin(np.abs(rgrid - f.r))
-                zi = np.argmin(np.abs(zgrid - f.z))
-                # Set current density for that unit cell
-                # so that the total for the cell comes out to the
-                # correct total current
-                jtor[ri, zi] += f.n / area
+        polygons = [
+            Polygon.from_bounds(r - w / 2, z - w / 2, r + w / 2, z + w / 2)
+            for r, z in zip(self.rs, self.zs)
+        ]
 
-            # Solve flux field
-            psi = solve_flux_axisymmetric(grids, meshes, jtor)  # [Wb/A]
+        # Point-source representation
+        fil_rzn = (self.rs, self.zs, self.ns)
 
-            # Extract flux density
-            br, bz = calc_flux_density_from_flux(psi, rmesh, zmesh)  # [T/A]
-
-            return psi, br, bz
-
-        else:
-            return None
+        # Local field solve
+        return local_fields(fil_rzn, polygons)
 
     @cached_property
     def local_field_interpolators(
         self,
-    ) -> Optional[
-        tuple[MulticubicRectilinear, MulticubicRectilinear, MulticubicRectilinear]
-    ]:
+    ) -> tuple[MulticubicRegular, MulticubicRegular, MulticubicRegular]:
         """Build interpolators over the solved local fields, if available"""
-        grids = self.grids
-        local_fields = self.local_fields
-
-        if grids is not None and local_fields is not None:
-            psi, br, bz = local_fields
-            grids = [x for x in grids]
-            psi_interp = MulticubicRectilinear.new(grids, psi)
-            br_interp = MulticubicRectilinear.new(grids, br)
-            bz_interp = MulticubicRectilinear.new(grids, bz)
-
-            return psi_interp, br_interp, bz_interp
-        else:
-            return None
+        return (
+            self.local_fields.psi_per_amp_interpolator,
+            self.local_fields.br_per_amp_interpolator,
+            self.local_fields.bz_per_amp_interpolator,
+        )
 
     @cached_property
     def extent(self) -> tuple[float, float, float, float]:

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -1,0 +1,368 @@
+"""
+Local flux solve in the vicinity of a collection of filaments with polygon sections
+that do not necessarily fall on a rectangular grid by allocating the fraction of
+intersecting polygon area to each mesh cell.
+"""
+
+from itertools import chain
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pytest import approx
+
+from shapely import Polygon
+
+from interpn import MulticubicRegular
+
+from scipy.optimize import fsolve
+
+from device_inductance.logging import log
+from device_inductance.utils import solve_flux_axisymmetric, calc_flux_density_from_flux
+
+
+RMIN = 2e-2
+"""[m] minimum r-value to allow in local solver grid"""
+
+N_INSIDE = 8
+"""Target number of grid points inside filament extent"""
+
+N_OUTSIDE = 9
+"""Target number of grid points on either side of filament extent"""
+
+
+@dataclass(frozen=True)
+class LocalFields:
+    """Outputs of local field solve"""
+
+    jtor_per_amp: NDArray
+    """[1/m^2] normalized current density map"""
+
+    psi_per_amp: NDArray
+    """[Wb/A] normalized poloidal flux"""
+
+    br_per_amp: NDArray
+    """[T/A] normalized flux density, r-component"""
+
+    bz_per_amp: NDArray
+    """[T/A] normalized flux density, z-component"""
+
+    psi_per_amp_interpolator: MulticubicRegular
+    """[Wb/A] normalized poloidal flux, hermite spline interpolator"""
+
+    br_per_amp_interpolator: MulticubicRegular
+    """[T/A] normalized flux density, r-component, hermite spline interpolator"""
+
+    bz_per_amp_interpolator: MulticubicRegular
+    """[T/A] normalized flux density, z-component, hermite spline interpolator"""
+
+    grids: tuple[NDArray, NDArray]
+    """[m] 1D computational grids"""
+
+    meshes: tuple[NDArray, NDArray]
+    """[m] 2D computational meshgrids"""
+
+
+def local_fields(
+    fil_rzn: tuple[NDArray, NDArray, NDArray], polygons: list[Polygon]
+) -> LocalFields:
+    """
+    Estimate local self-field of a collection of filaments with polygon representations.
+    """
+    rs, zs, ns = fil_rzn
+    grids_regular = _make_grids_regular(rs, zs)
+
+    if grids_regular is not None:  # The filaments land on a regular grid
+        grids = grids_regular
+    else:  # The filaments do not land on any regular grid
+        grids = _make_grids_irregular(polygons)
+
+    meshes = _make_mesh(grids)
+    dr = grids[0][1] - grids[0][0]
+    dz = grids[1][1] - grids[1][0]
+    dxgrid = (dr, dz)
+
+    if grids_regular is not None:
+        # Just put all the current for each filament on its corresponding mesh cell
+        jtor_per_amp = _allocate_current_regular(fil_rzn, grids, meshes)
+    else:
+        # Split polygons between mesh cells, run flux solve, and back-out B-fields
+        jtor_per_amp = _allocate_current_irregular(fil_rzn, polygons, meshes, dxgrid)
+
+    psi_per_amp, br_per_amp, bz_per_amp = _local_fields(jtor_per_amp, grids, meshes)
+
+    # Make interpolators
+    dims = [len(grids[0]), len(grids[1])]
+    starts = np.array([grids[0][0], grids[1][0]])
+    steps = np.array(dxgrid)
+    psi_per_amp_interpolator = MulticubicRegular.new(
+        dims, starts, steps, psi_per_amp.flatten()
+    )
+    br_per_amp_interpolator = MulticubicRegular.new(
+        dims, starts, steps, br_per_amp.flatten()
+    )
+    bz_per_amp_interpolator = MulticubicRegular.new(
+        dims, starts, steps, bz_per_amp.flatten()
+    )
+
+    # Pack numerous outputs into a struct
+    result = LocalFields(
+        jtor_per_amp,
+        psi_per_amp,
+        br_per_amp,
+        bz_per_amp,
+        psi_per_amp_interpolator,
+        br_per_amp_interpolator,
+        bz_per_amp_interpolator,
+        grids,
+        meshes,
+    )
+
+    return result
+
+
+def _filament_extent(polygons: list[Polygon]) -> tuple[float, float, float, float]:
+    """Get the (rmin, rmax, zmin, zmax) extent that bounds the filament polygons."""
+    r = np.array([*chain([p.boundary.xy[0] for p in polygons])])
+    z = np.array([*chain([p.boundary.xy[1] for p in polygons])])
+
+    rmin, rmax = np.min(r), np.max(r)
+    zmin, zmax = np.min(z), np.max(z)
+    extent = (float(rmin), float(rmax), float(zmin), float(zmax))
+
+    return extent
+
+
+def _make_grids_irregular(polygons: list[Polygon]) -> tuple[NDArray, NDArray]:
+    """Make grids that bound the filament extent plus at least 7 cells outside to support a 4th order difference method."""
+    rmin, rmax, zmin, zmax = _filament_extent(polygons)
+
+    if rmin < 0.0:
+        raise ValueError(
+            f"Minimum r-coordinate of a filament is <{RMIN} [m], which does not leave enough room to set boundary conditions."
+        )
+    if rmin < RMIN:
+        log().warning(
+            f"Clamping filament polygon bounds to minimum radius of {RMIN} [m], which may distort fields."
+        )
+        rmin = RMIN
+
+    rspan = rmax - rmin
+    zspan = zmax - zmin
+
+    # This is the grid step size if there is no conflict with crossing R=0
+    n_inside = max(int(float(len(polygons) ** 0.5)), N_INSIDE)
+    dr = rspan / n_inside
+    dz = zspan / n_inside
+
+    # Take the smaller step size of the two for both;
+    # the method can handle different step sizes on each axis, but best
+    # results are obtained with grid cells of equal aspect ratio.
+    dr = min(dr, dz)
+    dz = dr
+
+    # Check if we are interfering with R=0
+    # and decrease size of both r-step and z-step until that is resolved
+    # to keep the innermost point off of R=0.
+    while rmin - dr * N_OUTSIDE < RMIN / 2.0:
+        dr /= 2.0
+    dz = dr
+
+    # Make the actual grids
+    rgrid = np.arange(rmin - dr * N_OUTSIDE, rmax + dr * N_OUTSIDE + dr, dr)
+    zgrid = np.arange(zmin - dz * N_OUTSIDE, zmax + dz * N_OUTSIDE + dz, dz)
+
+    nr, nz = len(rgrid), len(zgrid)
+    if nz > 100 or nz > 100:
+        log().warning(
+            f"Using an excessively large mesh ({nr} X {nz}) to represent filament local flux solve due to proximity to R=0."
+        )
+
+    return rgrid, zgrid
+
+
+def _make_mesh(grids: tuple[NDArray, NDArray]) -> tuple[NDArray, NDArray]:
+    rmesh, zmesh = np.meshgrid(*grids, indexing="ij")
+    return rmesh, zmesh
+
+
+def _allocate_current_irregular(
+    fil_rzn: tuple[NDArray, NDArray, NDArray],
+    fil_polygons: list[Polygon],
+    meshes: tuple[NDArray, NDArray],
+    dxgrid: tuple[float, float],
+) -> NDArray:
+    """Convert a collection of filaments with polygon representations to a jtor array mapped on to the meshes."""
+    rs, zs, ns = fil_rzn
+    total_turns = np.sum(ns)
+    dr, dz = dxgrid
+    rmesh, zmesh = meshes
+
+    # Make polygons for each mesh cell
+    def cell_to_poly(r, z) -> Polygon:
+        """Rectangular polygon representing a mesh cell"""
+        return Polygon.from_bounds(r - dr / 2, z - dz / 2, r + dr / 2, z + dz / 2)
+
+    mesh_polygons = [
+        cell_to_poly(r, z) for r, z in zip(rmesh.flatten(), zmesh.flatten())
+    ]
+
+    # For each filament polygon, find the fraction of its area
+    # that falls in each mesh cell polygon.
+    # The fraction of the total area assigned to each filament should be already accounted in the `n` for the filament.
+    itor_per_amp = np.zeros_like(rmesh.flatten())
+    for i in range(len(itor_per_amp)):
+        mp = mesh_polygons[i]
+        for n, fp in zip(ns, fil_polygons):
+            intersection = fp.intersection(mp)
+            if isinstance(intersection, Polygon):
+                itor_per_amp[i] += n * intersection.area / fp.area
+
+    assert np.sum(itor_per_amp) == approx(total_turns, rel=1e-6, abs=1e-6)
+    itor_per_amp = itor_per_amp.reshape(rmesh.shape)
+
+    # Shift the centroid of the current map to match the centroid of the filaments
+    rcfil = np.sum(rs * ns) / total_turns # [m]
+    zcfil = np.sum(zs * ns) / total_turns
+    fil_centroid = np.array((rcfil, zcfil))
+
+    def shift2d(v, shift):
+        """Shift a fraction of each cell's current to its neighbor in a 2D array"""
+        rshift, zshift = shift
+        nr, nz = v.shape
+
+        # Make linear basis functions about the center of the array
+        rbasis = rshift * (np.array(range(nr), dtype=float) - (nr/2)) / (nr / 2)
+        zbasis = zshift * (np.array(range(nz), dtype=float) - (nz/2)) / (nz / 2)
+        
+        # Broadcast shift bases
+        vshifted = v + v * rbasis.reshape(nr, 1) + v * zbasis.reshape(1, nz)
+
+        # Rescale to preserve total
+        vshifted *= (np.sum(v) / np.sum(vshifted))
+
+        return vshifted
+
+
+    def itor_centroid(shift):
+        """Find the mesh current centroid given some percent shift in current between neighboring cells"""
+        itor_shifted = shift2d(itor_per_amp, shift)
+        isum = np.sum(itor_shifted)
+        rc = np.sum(itor_shifted * rmesh) / isum
+        zc = np.sum(itor_shifted * zmesh) / isum
+
+        return np.array((rc, zc))
+    
+    # Solve a shift to match the current centroid of the mesh representation to the
+    # current centroid of the filament representation.
+    shift = fsolve(lambda shift: itor_centroid(shift) - fil_centroid, x0=np.zeros(2))
+    itor_per_amp = shift2d(itor_per_amp, shift)
+
+    # Current density from current
+    jtor_per_amp = itor_per_amp / (dr * dz)
+    assert np.sum(jtor_per_amp) == approx(total_turns / (dr * dz), rel=1e-6, abs=1e-6)
+
+    return jtor_per_amp
+
+
+def _allocate_current_regular(
+    fil_rzn: tuple[NDArray, NDArray, NDArray],
+    grids: tuple[NDArray, NDArray],
+    meshes: tuple[NDArray, NDArray],
+) -> NDArray:
+    """Assign filament current-turn density for filaments that are known to land on grid points"""
+    rgrid, zgrid = grids
+    dr = rgrid[1] - rgrid[0]  # [m]
+    dz = zgrid[1] - zgrid[0]  # [m]
+    area = dr * dz  # [m^2]
+
+    # Map current density per amp
+    jtor_per_amp = np.zeros_like(meshes[0])  # [A-turns/m^2 / A]
+    for r, z, n in zip(*fil_rzn):
+        # Get indices of location of this filament
+        ri = np.argmin(np.abs(rgrid - r))
+        zi = np.argmin(np.abs(zgrid - z))
+        # Set current density for that unit cell
+        # so that the total for the cell comes out to the
+        # correct total current
+        jtor_per_amp[ri, zi] += n / area
+
+    return jtor_per_amp
+
+
+def _local_fields(
+    jtor: NDArray, grids: tuple[NDArray, NDArray], meshes: tuple[NDArray, NDArray]
+) -> tuple[NDArray, NDArray, NDArray]:
+    rmesh, zmesh = meshes
+
+    # Solve flux field
+    psi = solve_flux_axisymmetric(grids, meshes, jtor)  # [Wb/A]
+
+    # Extract flux density
+    br, bz = calc_flux_density_from_flux(psi, rmesh, zmesh)  # [T/A]
+
+    return psi, br, bz
+
+
+def _make_grids_regular(rs: NDArray, zs: NDArray) -> tuple[NDArray, NDArray] | None:
+    """Generate a set of regular r,z grids that span the coil winding pack centers exactly
+    if possible, or None if the winding pack can't be represented exactly.
+
+    Adds 4 grid cells of padding around the winding pack to deconflict the
+    cells with nonzero current density from the boundary conditions of a
+    flux solve.
+
+    If only one unit cell is present on either axis, the grid will be
+    expanded 1cm in either direction.
+    """
+
+    # Get coordinates with a unit cell
+    unique_r = np.array(sorted(list(set(rs))))  # [m]
+    unique_z = np.array(sorted(list(set(zs))))
+
+    # Make sure there are enough unit cells to work with,
+    # expanding dimensions if necessary
+    if len(unique_r) == 1:
+        r = unique_r[0]
+        unique_r = [r - 1e-2, r, r + 1e-2]
+    if len(unique_z) == 1:
+        z = unique_z[0]
+        unique_z = [z - 1e-2, z, z + 1e-2]
+    if len(unique_r) < 2 or len(unique_z) < 2:
+        log().error("Failed to expand grid dimensionality. This is a bug.")
+        return None
+
+    # Check if the coordinates have regular spacing,
+    # which is required to support the finite difference solve
+    drs = np.diff(unique_r)
+    drmean = np.mean(drs)
+    if np.any(np.abs(drs - drmean) / drmean > 1e-4):
+        return None
+    dzs = np.diff(unique_z)
+    dzmean = np.mean(dzs)
+    if np.any(np.abs(dzs - dzmean) / dzmean > 1e-4):
+        return None
+
+    # Extend grids by a few cells outside the winding pack
+    # 7 is the true minimum; 2x 4th-order finite difference patches
+    # will be stacked to extract the flux then the flux density, which means
+    # 7 cells see direct interaction with boundary conditions and must not
+    # have nonzero current density to produce sane results; npad = 6 produces junk outputs.
+    npad = 7
+    nr = len(unique_r) + 2 * npad
+    nz = len(unique_z) + 2 * npad
+    r_pad = npad * drmean
+    z_pad = npad * dzmean
+    rgrid = np.linspace(unique_r[0] - r_pad, unique_r[-1] + r_pad, nr)
+    zgrid = np.linspace(unique_z[0] - z_pad, unique_z[-1] + z_pad, nz)
+
+    # Make sure the grid doesn't cross zero.
+    # If this check becomes a problem, there is an alternate strategy
+    # to double resolution and spread the coil's current density mapping
+    # across more than one neighboring cell, but that is too much complexity
+    # to implement proactively.
+    if rgrid[0] < 0.0:
+        return None
+
+    return (rgrid, zgrid)

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -230,6 +230,8 @@ def _allocate_current_irregular(
     itor_per_amp = itor_per_amp.reshape(rmesh.shape)
 
     # Shift the centroid of the current map to match the centroid of the filaments
+    # Otherwise, there will be a slight discontinuity between the local field map and the
+    # far-field values calculated from direct filament functions.
     rcfil = np.sum(rs * ns) / total_turns  # [m]
     zcfil = np.sum(zs * ns) / total_turns
     fil_centroid = np.array((rcfil, zcfil))

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -310,8 +310,8 @@ def _allocate_current_regular(
     jtor_per_amp = np.zeros_like(meshes[0])  # [A-turns/m^2 / A]
     for r, z, n in zip(*fil_rzn):
         # Get indices of location of this filament
-        ri = np.argmin(np.abs(rgrid - r))
-        zi = np.argmin(np.abs(zgrid - z))
+        ri = int((r - np.min(rgrid)) / dr)
+        zi = int((z - np.min(zgrid)) / dz)
         # Set current density for that unit cell
         # so that the total for the cell comes out to the
         # correct total current

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -310,8 +310,8 @@ def _allocate_current_regular(
     jtor_per_amp = np.zeros_like(meshes[0])  # [A-turns/m^2 / A]
     for r, z, n in zip(*fil_rzn):
         # Get indices of location of this filament
-        ri = int((r - np.min(rgrid)) / dr)
-        zi = int((z - np.min(zgrid)) / dz)
+        ri = int((r - rgrid[0]) / dr)
+        zi = int((z - zgrid[0]) / dz)
         # Set current density for that unit cell
         # so that the total for the cell comes out to the
         # correct total current

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -12,7 +12,7 @@ from numpy.typing import NDArray
 
 from pytest import approx
 
-from shapely import Polygon
+from shapely import Polygon, GeometryCollection, MultiPolygon
 
 from interpn import MulticubicRegular
 
@@ -222,9 +222,24 @@ def _allocate_current_irregular(
     for i in range(len(itor_per_amp)):
         mp = mesh_polygons[i]
         for n, fp in zip(ns, fil_polygons):
+            # Find overlapping area between this filament and this grid cell.
+            # If the filament polygon is not well-behaved, we can end up with more
+            # than one distinct overlapping region.
             intersection = fp.intersection(mp)
+            overlap_area = 0.0
             if isinstance(intersection, Polygon):
-                itor_per_amp[i] += n * intersection.area / fp.area
+                # Simple intersection
+                overlap_area = intersection.area
+            elif isinstance(intersection, GeometryCollection) or isinstance(
+                intersection, MultiPolygon
+            ):
+                # Non-simple intersection
+                for x in intersection.geoms:
+                    if isinstance(x, Polygon):
+                        overlap_area += x.area
+
+            # Add contribution to this grid cell from this filament
+            itor_per_amp[i] += n * overlap_area / fp.area
 
     assert np.sum(itor_per_amp) == approx(total_turns, rel=1e-6, abs=1e-6)
     itor_per_amp = itor_per_amp.reshape(rmesh.shape)

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -226,17 +226,13 @@ def _allocate_current_irregular(
             # If the filament polygon is not well-behaved, we can end up with more
             # than one distinct overlapping region.
             intersection = fp.intersection(mp)
-            overlap_area = 0.0
             if isinstance(intersection, Polygon):
                 # Simple intersection
                 overlap_area = intersection.area
-            elif isinstance(intersection, GeometryCollection) or isinstance(
-                intersection, MultiPolygon
-            ):
+            elif isinstance(intersection, (GeometryCollection, MultiPolygon)):
                 # Non-simple intersection
-                for x in intersection.geoms:
-                    if isinstance(x, Polygon):
-                        overlap_area += x.area
+                g = intersection.geoms
+                overlap_area = sum([x.area for x in g if isinstance(x, Polygon)])
 
             # Add contribution to this grid cell from this filament
             itor_per_amp[i] += n * overlap_area / fp.area

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -233,6 +233,8 @@ def _allocate_current_irregular(
                 # Non-simple intersection
                 g = intersection.geoms
                 overlap_area = sum([x.area for x in g if isinstance(x, Polygon)])
+            else:
+                raise TypeError(f"Unexpected intersection result: {intersection}")
 
             # Add contribution to this grid cell from this filament
             itor_per_amp[i] += n * overlap_area / fp.area

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -242,8 +242,14 @@ def _allocate_current_irregular(
         nr, nz = v.shape
 
         # Make linear basis functions about the center of the array
-        rbasis = rshift * (np.array(range(nr), dtype=float) - (nr / 2)) / (nr / 2)
-        zbasis = zshift * (np.array(range(nz), dtype=float) - (nz / 2)) / (nz / 2)
+        rinds = np.array(range(nr), dtype=float)  # Indices as coordinate
+        zinds = np.array(range(nz), dtype=float)
+        rmid = (nr - 1) / 2  # Normalization factor to map coordinates to [-1, 1]
+        zmid = (nz - 1) / 2
+        rcoord = (rinds - rmid) / rmid  # Normalized array coordinates
+        zcoord = (zinds - zmid) / zmid
+        rbasis = rshift * rcoord  # Shift basis functions
+        zbasis = zshift * zcoord
 
         # Broadcast shift bases
         vshifted = v + v * rbasis.reshape(nr, 1) + v * zbasis.reshape(1, nz)

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -69,6 +69,13 @@ def local_fields(
 ) -> LocalFields:
     """
     Estimate local self-field of a collection of filaments with polygon representations.
+
+    Args:
+        fil_rzn: r-coord, z-coord, and number of turns for each filament
+        polygons: polygon section of each filament
+
+    Returns:
+        Structure containing local field map components and interpolators
     """
     rs, zs, ns = fil_rzn
     grids_regular = _make_grids_regular(rs, zs)
@@ -223,7 +230,7 @@ def _allocate_current_irregular(
     itor_per_amp = itor_per_amp.reshape(rmesh.shape)
 
     # Shift the centroid of the current map to match the centroid of the filaments
-    rcfil = np.sum(rs * ns) / total_turns # [m]
+    rcfil = np.sum(rs * ns) / total_turns  # [m]
     zcfil = np.sum(zs * ns) / total_turns
     fil_centroid = np.array((rcfil, zcfil))
 
@@ -233,17 +240,16 @@ def _allocate_current_irregular(
         nr, nz = v.shape
 
         # Make linear basis functions about the center of the array
-        rbasis = rshift * (np.array(range(nr), dtype=float) - (nr/2)) / (nr / 2)
-        zbasis = zshift * (np.array(range(nz), dtype=float) - (nz/2)) / (nz / 2)
-        
+        rbasis = rshift * (np.array(range(nr), dtype=float) - (nr / 2)) / (nr / 2)
+        zbasis = zshift * (np.array(range(nz), dtype=float) - (nz / 2)) / (nz / 2)
+
         # Broadcast shift bases
         vshifted = v + v * rbasis.reshape(nr, 1) + v * zbasis.reshape(1, nz)
 
         # Rescale to preserve total
-        vshifted *= (np.sum(v) / np.sum(vshifted))
+        vshifted *= np.sum(v) / np.sum(vshifted)
 
         return vshifted
-
 
     def itor_centroid(shift):
         """Find the mesh current centroid given some percent shift in current between neighboring cells"""
@@ -253,7 +259,7 @@ def _allocate_current_irregular(
         zc = np.sum(itor_shifted * zmesh) / isum
 
         return np.array((rc, zc))
-    
+
     # Solve a shift to match the current centroid of the mesh representation to the
     # current centroid of the filament representation.
     shift = fsolve(lambda shift: itor_centroid(shift) - fil_centroid, x0=np.zeros(2))

--- a/device_inductance/local.py
+++ b/device_inductance/local.py
@@ -310,8 +310,8 @@ def _allocate_current_regular(
     jtor_per_amp = np.zeros_like(meshes[0])  # [A-turns/m^2 / A]
     for r, z, n in zip(*fil_rzn):
         # Get indices of location of this filament
-        ri = int((r - rgrid[0]) / dr)
-        zi = int((z - zgrid[0]) / dz)
+        ri = np.argmin(np.abs(rgrid - r))
+        zi = np.argmin(np.abs(zgrid - z))
         # Set current density for that unit cell
         # so that the total for the cell comes out to the
         # correct total current

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "device_inductance"
-version = "2.2.0"
+version = "3.0.0"
 description = "Tokamak core inductance matrices and flux tables"
 authors = [{ name = "Commonwealth Fusion Systems", email = "jlogan@cfs.energy" }]
 requires-python = ">=3.10, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ device_inductance = ['py.typed']
 target-version = "py310"
 
 [tool.coverage.report]
-fail_under = 96
+fail_under = 95

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ packages = ["device_inductance"]
 device_inductance = ['py.typed']
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 
 [tool.coverage.report]
 fail_under = 96

--- a/test/test_forces.py
+++ b/test/test_forces.py
@@ -128,17 +128,14 @@ def test_circuit_coil_forces(typical_outputs: device_inductance.TypicalOutputs):
                 pass
             elif coils[j].name in circuit_coil_names:
                 # Self-field with smooth field available
-
-                # print(i, j, circuits[i].name, coils[j].name, f"{fr[i,j]:e},{fr_interped:e}", f"{fz[i,j]:e},{fz_interped:e}")
                 assert fr[i, j] == approx(fr_interped, rel=6e-2, abs=6e-6)
 
-                # In single-coil circuits, only self-field is present, and z-force should be near zero
-                # This also holds for circuits where the coils are aligned vertically.
-                # All the coils in the device description fall into one of these categories as of
-                # 2025-03-20, but this may need an update someday if other kinds of configurations are added.
-                assert fz[i, j] == approx(0.0, abs=1e-6)
+                # In single-coil circuits, only self-field is present, and z-force should be near zero.
+                # Because some of the coils' self-field is based on an inexact mapping of turns on to a regular grid,
+                # the force may not be _exactly_ zero, but should be small enough not to be important to structural
+                # estimates.
+                assert fz[i, j] == approx(0.0, abs=5e-3)
             else:
-                # print(i, j, circuits[i].name, coils[j].name, f"{fr[i,j]:e},{fr_interped:e}", f"{fz[i,j]:e},{fz_interped:e}")
                 assert fr[i, j] == approx(fr_interped, rel=6e-2, abs=6e-6)
                 assert fz[i, j] == approx(fz_interped, rel=6e-2, abs=6e-6)
 

--- a/uv.lock
+++ b/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "device-inductance"
-version = "2.2.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cfsem" },


### PR DESCRIPTION
## 3.0.0 - 2025-07-01

### Added

* Add `local` module with self-field flux and B-field calculations for coil winding packs
* Add functionality for mapping coil winding packs on irregular grids (like VS coils) on to a regular grid for local field solve

### Changed

* !Return a more featured struct of data from coil self-field calcs instead of a tuple
* !Return MulticubicRegular interpolators as coil field interpolators instead of MulticubicRectilinear
* Make coil self-field calc return types non-optional since all non-error branches now produce a valid output
